### PR TITLE
feat: remove deprecated RestAPI provider

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-02-14T15:13:37Z",
+  "generated_at": "2023-02-20T16:24:16Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -82,7 +82,7 @@
         "hashed_secret": "ff9ee043d85595eb255c05dfe32ece02a53efbb2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 19,
+        "line_number": 17,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/README.md
+++ b/README.md
@@ -10,29 +10,12 @@ This module supports:
 - Creating a [Key Protect instance](https://cloud.ibm.com/docs/key-protect?topic=key-protect-about)
 - Enabling a [metrics policy](https://cloud.ibm.com/docs/key-protect?topic=key-protect-manage-monitor-metrics) for the instance
 
-Although the restapi provider is currently a required provider for this module, it is no longer used for any function within the module. It will be removed in the next major version release of this module.
-
 ## Usage
 
 ```hcl
 provider "ibm" {
   ibmcloud_api_key = "XXXXXXXXXX"
   region           = "us-south"
-}
-
-# Retrieve IAM access token (required for restapi provider)
-data "ibm_iam_auth_token" "token_data" {
-}
-provider "restapi" {
-  uri                   = "https:"
-  write_returns_object  = false
-  create_returns_object = false
-  debug                 = false
-  headers = {
-    Authorization    = data.ibm_iam_auth_token.token_data.iam_access_token
-    Bluemix-Instance = module.key_protect_module.key_protect_guid
-    Content-Type     = "application/vnd.ibm.kms.policy+json"
-  }
 }
 
 module "key_protect_module" {
@@ -66,7 +49,6 @@ module "key_protect_module" {
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.49.0 |
-| <a name="requirement_restapi"></a> [restapi](#requirement\_restapi) | >= 1.18.0 |
 
 ## Modules
 

--- a/examples/default/provider.tf
+++ b/examples/default/provider.tf
@@ -2,21 +2,3 @@ provider "ibm" {
   ibmcloud_api_key = var.ibmcloud_api_key
   region           = var.region
 }
-
-# Deprecated
-# Retrieve IAM access token (required for restapi provider)
-data "ibm_iam_auth_token" "token_data" {
-}
-
-# Deprecated
-provider "restapi" {
-  uri                   = "https:"
-  write_returns_object  = false
-  create_returns_object = false
-  debug                 = false # set to true to show detailed logs, but use carefully as it might print sensitive values.
-  headers = {
-    Authorization    = data.ibm_iam_auth_token.token_data.iam_access_token
-    Bluemix-Instance = module.key_protect_module.key_protect_guid
-    Content-Type     = "application/vnd.ibm.kms.policy+json"
-  }
-}

--- a/examples/default/version.tf
+++ b/examples/default/version.tf
@@ -6,10 +6,5 @@ terraform {
       source  = "IBM-Cloud/ibm"
       version = "1.49.0"
     }
-    # Deprecated
-    restapi = {
-      source  = "Mastercard/restapi"
-      version = "1.18.0"
-    }
   }
 }

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -156,12 +156,6 @@
       "version_constraints": [
         "\u003e= 1.49.0"
       ]
-    },
-    "restapi": {
-      "source": "Mastercard/restapi",
-      "version_constraints": [
-        "\u003e= 1.18.0"
-      ]
     }
   },
   "managed_resources": {

--- a/version.tf
+++ b/version.tf
@@ -6,10 +6,5 @@ terraform {
       source  = "IBM-Cloud/ibm"
       version = ">= 1.49.0"
     }
-    # tflint-ignore: terraform_unused_required_providers
-    restapi = {
-      source  = "Mastercard/restapi"
-      version = ">= 1.18.0"
-    }
   }
 }


### PR DESCRIPTION
### Description
Remove the deprecated RestAPI provider from the module

### Types of changes in this PR

#### No release required

- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [ ] Other changes that don't affect Terraform code

#### Release required

- [ ] Bug fix (patch release (`x.x.X`): Change that fixes an issue and is compatible with earlier versions)
- [ ] New feature (minor release (`x.X.x`): Change that adds functionality and is compatible with earlier versions)
- [ ] Breaking change (major release (`X.x.x`): Change that is likely incompatible with previous versions)

##### Release notes content
Remove the deprecated RestAPI provider requirement, if you are already consuming this module please upgrade to v1.3.0 prior to consuming this release in order to avoid errors in the terraform state.

---

### Checklist for reviewers

- [ ] The PR references a GitHub issue.
- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Merge by using "Squash and merge".
- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author.

    The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
