### PR TITLE
feat: add remaining instance policies

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-04-29T03:18:00Z",
+  "generated_at": "2023-05-11T17:04:05Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -82,7 +82,7 @@
         "hashed_secret": "ff9ee043d85595eb255c05dfe32ece02a53efbb2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17,
+        "line_number": 21,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-05-11T17:04:05Z",
+  "generated_at": "2023-05-11T21:50:38Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -88,7 +88,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.59.dss",
+  "version": "0.13.1+ibm.60.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/README.md
+++ b/README.md
@@ -7,8 +7,12 @@
 [![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com/)
 
 This module supports:
+
 - Creating a [Key Protect instance](https://cloud.ibm.com/docs/key-protect?topic=key-protect-about)
+- Enabling a [rotation policy](https://cloud.ibm.com/docs/key-protect?topic=key-protect-set-rotation-policy) for the instance
+- Enabling a [dual authorization policy](https://cloud.ibm.com/docs/key-protect?topic=key-protect-manage-dual-auth) for the instance
 - Enabling a [metrics policy](https://cloud.ibm.com/docs/key-protect?topic=key-protect-manage-monitor-metrics) for the instance
+- Enabling a [key create and import access policy](https://cloud.ibm.com/docs/key-protect?topic=key-protect-manage-keyCreateImportAccess) for the instance
 
 ## Usage
 
@@ -65,11 +69,16 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_dual_auth_delete_enabled"></a> [dual\_auth\_delete\_enabled](#input\_dual\_auth\_delete\_enabled) | If set to true, Key Protect enables a dual authorization policy on the instance. Note: Once the dual authorization policy is set on the instance, it cannot be reverted. An instance with dual authorization policy enabled cannot be destroyed using Terraform. | `bool` | `false` | no |
+| <a name="input_key_create_import_access_enabled"></a> [key\_create\_import\_access\_enabled](#input\_key\_create\_import\_access\_enabled) | If set to true, Key Protect enables a key create import access policy on the instance | `bool` | `true` | no |
+| <a name="input_key_create_import_access_settings"></a> [key\_create\_import\_access\_settings](#input\_key\_create\_import\_access\_settings) | Key create import access policy settings to configure if var.enable\_key\_create\_import\_access\_policy is true. For more info see https://cloud.ibm.com/docs/key-protect?topic=key-protect-manage-keyCreateImportAccess | <pre>object({<br>    create_root_key     = optional(bool, true)<br>    create_standard_key = optional(bool, true)<br>    import_root_key     = optional(bool, true)<br>    import_standard_key = optional(bool, true)<br>    enforce_token       = optional(bool, false)<br>  })</pre> | `{}` | no |
 | <a name="input_key_protect_name"></a> [key\_protect\_name](#input\_key\_protect\_name) | The name to give the Key Protect instance that will be provisioned | `string` | n/a | yes |
 | <a name="input_metrics_enabled"></a> [metrics\_enabled](#input\_metrics\_enabled) | If set to true, Key Protect enables metrics on the Key Protect instance. In order to view metrics, you will need a Monitoring (Sysdig) instance that is located in the same region as the Key Protect instance. Once you provision the Monitoring instance, you will need to enable platform metrics. | `bool` | `true` | no |
 | <a name="input_plan"></a> [plan](#input\_plan) | Plan for the Key Protect instance. Currently only 'tiered-pricing' is supported | `string` | `"tiered-pricing"` | no |
 | <a name="input_region"></a> [region](#input\_region) | Region where the Key Protect instance will be provisioned | `string` | n/a | yes |
 | <a name="input_resource_group_id"></a> [resource\_group\_id](#input\_resource\_group\_id) | Resource Group ID where the Key Protect instance will be provisioned | `string` | n/a | yes |
+| <a name="input_rotation_enabled"></a> [rotation\_enabled](#input\_rotation\_enabled) | If set to true, Key Protect enables a rotation policy on the Key Protect instance. | `bool` | `true` | no |
+| <a name="input_rotation_interval_month"></a> [rotation\_interval\_month](#input\_rotation\_interval\_month) | Specifies the key rotation time interval in months. Must be between 1 and 12 inclusive. | `number` | `1` | no |
 | <a name="input_service_endpoints"></a> [service\_endpoints](#input\_service\_endpoints) | Types of the service endpoints to be set for the Key Protect instance. Possible values are 'public', 'private', or 'public-and-private' | `string` | `"public-and-private"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | List of tags to associate with the Key Protect instance | `list(string)` | `[]` | no |
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ module "key_protect_module" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.49.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.53.0 |
 
 ## Modules
 

--- a/examples/default/version.tf
+++ b/examples/default/version.tf
@@ -4,7 +4,7 @@ terraform {
     # Pin to the lowest provider version of the range defined in the main module's version.tf to ensure lowest version still works
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.49.0"
+      version = "1.53.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,22 @@ resource "ibm_resource_instance" "key_protect_instance" {
 
 resource "ibm_kms_instance_policies" "key_protect_instance_policies" {
   instance_id = ibm_resource_instance.key_protect_instance.guid
+  rotation {
+    enabled        = var.rotation_enabled
+    interval_month = var.rotation_interval_month
+  }
+  dual_auth_delete {
+    enabled = var.dual_auth_delete_enabled
+  }
   metrics {
     enabled = var.metrics_enabled
+  }
+  key_create_import_access {
+    enabled             = var.key_create_import_access_enabled
+    create_root_key     = var.key_create_import_access_settings.create_root_key
+    create_standard_key = var.key_create_import_access_settings.create_standard_key
+    import_root_key     = var.key_create_import_access_settings.import_root_key
+    import_standard_key = var.key_create_import_access_settings.import_standard_key
+    enforce_token       = var.key_create_import_access_settings.enforce_token
   }
 }

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -204,7 +204,7 @@
     "ibm": {
       "source": "IBM-Cloud/ibm",
       "version_constraints": [
-        "\u003e= 1.49.0"
+        "\u003e= 1.53.0"
       ]
     }
   },

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -1,6 +1,36 @@
 {
   "path": ".",
   "variables": {
+    "dual_auth_delete_enabled": {
+      "name": "dual_auth_delete_enabled",
+      "type": "bool",
+      "description": "If set to true, Key Protect enables a dual authorization policy on the instance. Note: Once the dual authorization policy is set on the instance, it cannot be reverted. An instance with dual authorization policy enabled cannot be destroyed using Terraform.",
+      "default": false,
+      "pos": {
+        "filename": "variables.tf",
+        "line": 65
+      }
+    },
+    "key_create_import_access_enabled": {
+      "name": "key_create_import_access_enabled",
+      "type": "bool",
+      "description": "If set to true, Key Protect enables a key create import access policy on the instance",
+      "default": true,
+      "pos": {
+        "filename": "variables.tf",
+        "line": 77
+      }
+    },
+    "key_create_import_access_settings": {
+      "name": "key_create_import_access_settings",
+      "type": "object({\n    create_root_key     = optional(bool, true)\n    create_standard_key = optional(bool, true)\n    import_root_key     = optional(bool, true)\n    import_standard_key = optional(bool, true)\n    enforce_token       = optional(bool, false)\n  })",
+      "description": "Key create import access policy settings to configure if var.enable_key_create_import_access_policy is true. For more info see https://cloud.ibm.com/docs/key-protect?topic=key-protect-manage-keyCreateImportAccess",
+      "default": {},
+      "pos": {
+        "filename": "variables.tf",
+        "line": 83
+      }
+    },
     "key_protect_name": {
       "name": "key_protect_name",
       "type": "string",
@@ -21,7 +51,7 @@
       "default": true,
       "pos": {
         "filename": "variables.tf",
-        "line": 48
+        "line": 71
       }
     },
     "plan": {
@@ -71,6 +101,26 @@
       "cloud_data_range": [
         "resolved_to:id"
       ]
+    },
+    "rotation_enabled": {
+      "name": "rotation_enabled",
+      "type": "bool",
+      "description": "If set to true, Key Protect enables a rotation policy on the Key Protect instance.",
+      "default": true,
+      "pos": {
+        "filename": "variables.tf",
+        "line": 48
+      }
+    },
+    "rotation_interval_month": {
+      "name": "rotation_interval_month",
+      "type": "number",
+      "description": "Specifies the key rotation time interval in months. Must be between 1 and 12 inclusive.",
+      "default": 1,
+      "pos": {
+        "filename": "variables.tf",
+        "line": 54
+      }
     },
     "service_endpoints": {
       "name": "service_endpoints",

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -12,12 +12,19 @@ import (
 const resourceGroup = "geretain-test-key-protect"
 const terraformDir = "examples/default"
 
+var ignoreUpdates = []string{
+	"module.key_protect_module.ibm_kms_instance_policies.key_protect_instance_policies",
+}
+
 func setupOptions(t *testing.T, prefix string) *testhelper.TestOptions {
 	options := testhelper.TestOptionsDefaultWithVars(&testhelper.TestOptions{
 		Testing:       t,
 		TerraformDir:  terraformDir,
 		Prefix:        prefix,
 		ResourceGroup: resourceGroup,
+		IgnoreUpdates: testhelper.Exemptions{
+			List: ignoreUpdates,
+		},
 	})
 
 	return options

--- a/variables.tf
+++ b/variables.tf
@@ -45,8 +45,49 @@ variable "plan" {
   }
 }
 
+variable "rotation_enabled" {
+  type        = bool
+  description = "If set to true, Key Protect enables a rotation policy on the Key Protect instance."
+  default     = true
+}
+
+variable "rotation_interval_month" {
+  type        = number
+  description = "Specifies the key rotation time interval in months. Must be between 1 and 12 inclusive."
+  default     = 1
+
+  validation {
+    condition     = (var.rotation_interval_month >= 1) && (var.rotation_interval_month <= 12)
+    error_message = "The rotation_interval_month must be between 1 and 12 inclusive."
+  }
+}
+
+variable "dual_auth_delete_enabled" {
+  type        = bool
+  description = "If set to true, Key Protect enables a dual authorization policy on the instance. Note: Once the dual authorization policy is set on the instance, it cannot be reverted. An instance with dual authorization policy enabled cannot be destroyed using Terraform."
+  default     = false
+}
+
 variable "metrics_enabled" {
   type        = bool
   description = "If set to true, Key Protect enables metrics on the Key Protect instance. In order to view metrics, you will need a Monitoring (Sysdig) instance that is located in the same region as the Key Protect instance. Once you provision the Monitoring instance, you will need to enable platform metrics."
   default     = true
+}
+
+variable "key_create_import_access_enabled" {
+  type        = bool
+  description = "If set to true, Key Protect enables a key create import access policy on the instance"
+  default     = true
+}
+
+variable "key_create_import_access_settings" {
+  type = object({
+    create_root_key     = optional(bool, true)
+    create_standard_key = optional(bool, true)
+    import_root_key     = optional(bool, true)
+    import_standard_key = optional(bool, true)
+    enforce_token       = optional(bool, false)
+  })
+  description = "Key create import access policy settings to configure if var.enable_key_create_import_access_policy is true. For more info see https://cloud.ibm.com/docs/key-protect?topic=key-protect-manage-keyCreateImportAccess"
+  default     = {}
 }

--- a/version.tf
+++ b/version.tf
@@ -4,7 +4,7 @@ terraform {
     # Use "greater than or equal to" range in modules
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.49.0"
+      version = ">= 1.53.0"
     }
   }
 }


### PR DESCRIPTION
### Description
adds instance policies available in the provider
remove deprecated RestAPI provider

### Types of changes in this PR

#### Changes that affect the core Terraform module or submodules
- [ ] Bug fix
- [x] New feature
- [ ] Dependency update

#### Changes that don't affect the core Terraform module or submodules
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [ ] Other

#### Release required?
Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning).

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Features:
- added the ability to configure rotation policy using new vars `rotation_enabled` (default value of true), and `rotation_interval_month` (default value of 1)
- added the ability to enable / disable a dual authorization policy on the instance using new var `dual_auth_delete_enabled` (default value of false). Note: Once the dual authorization policy is set on the instance, it cannot be reverted. An instance with dual authorization policy enabled cannot be destroyed using Terraform. 
- added the ability to configure key create import access policy settings using vars `key_create_import_access_enabled` (default value of true) and `key_create_import_access_settings` (If no value is passed it takes all of the objects default values. If only one is passed then it only overrides that one value so consumers do not have to pass the entire map in order to supply overrides they want to use).

---

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author. The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
- Merge by using "Squash and merge".
