### PR TITLE
fix: fix the way service endpoint type is passed to Key Protect

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-12-19T15:21:38Z",
+  "generated_at": "2023-12-20T15:21:38Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-12-18T15:21:38Z",
+  "generated_at": "2023-12-19T15:21:38Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/main.tf
+++ b/main.tf
@@ -13,8 +13,10 @@ resource "ibm_resource_instance" "key_protect_instance" {
   service           = "kms"
   plan              = var.plan
   location          = var.region
-  service_endpoints = var.service_endpoints
   tags              = var.tags
+  parameters = {
+    allowed_network : var.service_endpoints
+  }
 }
 
 ##############################################################################


### PR DESCRIPTION
### Description

In order to set endpoint type for Key Protect, you have to pass it as a parameter like this:
```
parameters = {
   allowed_network: "public-and-private",
 }
```

It should not be passed directly into `ibm_resource_instance` like we are doing now, as it is a special case.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
