### PR TITLE
fix: cleanup of the instance policy output

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -45,6 +45,17 @@ resource "ibm_kms_instance_policies" "key_protect_instance_policies" {
   }
 }
 
+locals {
+  instance_policies = {
+    dual_auth_delete         = [for obj in ibm_kms_instance_policies.key_protect_instance_policies.dual_auth_delete : obj if obj != null]
+    id                       = ibm_kms_instance_policies.key_protect_instance_policies.id
+    instance_id              = ibm_kms_instance_policies.key_protect_instance_policies.instance_id
+    key_create_import_access = [for obj in ibm_kms_instance_policies.key_protect_instance_policies.key_create_import_access : obj if obj != null]
+    metrics                  = [for obj in ibm_kms_instance_policies.key_protect_instance_policies.metrics : obj if obj != null]
+    rotation                 = [for obj in ibm_kms_instance_policies.key_protect_instance_policies.rotation : obj if obj != null]
+  }
+}
+
 ##############################################################################
 # Attach Access Tags
 ##############################################################################

--- a/main.tf
+++ b/main.tf
@@ -46,6 +46,8 @@ resource "ibm_kms_instance_policies" "key_protect_instance_policies" {
 }
 
 locals {
+  # instance policy output is not formatted correctly, cleanup done in this local
+  # tracking in issue: https://github.com/IBM-Cloud/terraform-provider-ibm/issues/5163
   instance_policies = {
     dual_auth_delete         = [for obj in ibm_kms_instance_policies.key_protect_instance_policies.dual_auth_delete : obj if obj != null]
     id                       = ibm_kms_instance_policies.key_protect_instance_policies.id

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,7 +18,7 @@ output "key_protect_name" {
 }
 
 output "key_protect_instance_policies" {
-  value       = ibm_kms_instance_policies.key_protect_instance_policies
+  value       = local.instance_policies
   description = "Instance Polices of the Key Protect instance"
 }
 


### PR DESCRIPTION
### Description

Addresses the odd formatting/data types in the output as shown in https://github.com/terraform-ibm-modules/terraform-ibm-kms-all-inclusive/issues/417, there is a field from the provider that doesn't appear in the provider reference documentation so it is not present in this output

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
