### PR TITLE
fix(deps): bump terraform IBM provider to 1.79.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ To attach access management tags to resources in this module, you need the follo
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.70.0, < 2.0.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.79.0, < 2.0.0 |
 
 ### Modules
 

--- a/examples/advanced/version.tf
+++ b/examples/advanced/version.tf
@@ -5,7 +5,7 @@ terraform {
     # module's version.tf (basic example), and 1 example that will always use the latest provider version (advanced example).
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.70.0"
+      version = ">= 1.79.0"
     }
   }
 }

--- a/examples/basic/version.tf
+++ b/examples/basic/version.tf
@@ -4,7 +4,7 @@ terraform {
     # Pin to the lowest provider version of the range defined in the main module's version.tf to ensure lowest version still works
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.70.0"
+      version = "1.79.0"
     }
   }
 }

--- a/version.tf
+++ b/version.tf
@@ -4,7 +4,7 @@ terraform {
     # Use "greater than or equal to" range in modules
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.70.0, < 2.0.0"
+      version = ">= 1.79.0, < 2.0.0"
     }
   }
 }


### PR DESCRIPTION
### Description

Pull in the fix for https://github.com/IBM-Cloud/terraform-provider-ibm/issues/6269

1.79.0 was picked as a minimum for the tests to run.
1.79.2 is not required, since no ibm_resource_keys are created.

Note: renovate terraform modules pipeline fails due to the test requiring 1.70.0 and the module requiring 1.79.0.

Addresses issue in #699

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
